### PR TITLE
Replace version number with more useful description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Webix UI v.5.2.0
-================
+Webix UI - JavaScript UI library for speeding up web development
+================================================================
 
 [![npm version](https://badge.fury.io/js/webix.svg)](https://badge.fury.io/js/webix)
 [![Join the chat at https://gitter.im/webix-hub/webix](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/webix-hub/webix) 
@@ -41,4 +41,4 @@ Starting from Webix 2.4, it possible to use a FLOSS Exception to the GPL License
 You can buy a commercial license and support subscription at http://webix.com
 
 
-(c) XB Software Ltd. 2013 - 2017
+(c) XB Software Ltd. 2013 - 2018


### PR DESCRIPTION
The version number doesn't offer additional information besides the npm verson badge below. It was also outdated. I've added instead a description, to help others discover this excellent but [under-marketed](https://github.com/webix-hub/tracker/issues/149) library.